### PR TITLE
Return A default Role if none is assigned to the user.

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,13 @@
+#### What does this PR do?
+
+#### Description of Task to be completed?
+
+#### How should this be manually tested?
+
+#### Any background context you want to provide?
+
+#### What are the relevant pivotal tracker stories?
+
+#### Screenshots (if appropriate)
+
+### Questions:

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 examples/node_modules
 coverage
 site
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -197,12 +197,20 @@ This methods loads the configuration json file. When this method it looks for `n
   });
 
   // When you use rules api, nacl will **not** to find the json/yaml file, so you can save your acl-rules with any Database;
-
+  
+// The default role alllows you to specify which role users will assumne if they are not assigned any
   acl.config({
     defaultRole: 'anonymous'
   });
 
-  // The default role alllows you to specify which role users will assumne if they are not assigned any
+  
+// By default this module will look for role in decoded object, if you would like to change the name of the object, you can specify this with decodedObjectName property.
+
+// As per the example below, this module will look for req.user.role as compared to default req.decoded.role.
+
+  acl.config({
+    decodedObjectName:'user'
+  })
 
 ```
 ## Response

--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ This methods loads the configuration json file. When this method it looks for `n
 - **yml**: when set to true means use yaml parser else JSON parser
 - **baseUrl**: The base url of your API e.g /developer/v1
 - **rules**: Allows you to set rules directly withour using config file.
+- **defaultRole** : The default role to be assigned to users if they have no role defined.
 
 ```js
   const acl = require('express-acl');
@@ -192,10 +193,16 @@ This methods loads the configuration json file. When this method it looks for `n
   // The above file can be acl.json or nacl.json or any_file_name.json
 
   acl.config({
-	rules: rulesArray
+	  rules: rulesArray
   });
 
   // When you use rules api, nacl will **not** to find the json/yaml file, so you can save your acl-rules with any Database;
+
+  acl.config({
+    defaultRole: 'anonymous'
+  });
+
+  // The default role alllows you to specify which role users will assumne if they are not assigned any
 
 ```
 ## Response

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -35,9 +35,7 @@ function getRules(path, encoding, isYaml) {
  */
 
 function getPolicy(permissions, resource) {
-  let policy = _.find(permissions, {
-    resource: resource
-  });
+  let policy = _.find(permissions, { resource });
 
   if (policy) {
     return {
@@ -48,19 +46,16 @@ function getPolicy(permissions, resource) {
   return policy;
 }
 
-function getRole(req, res, options) {
 
-  options = options || {};
+function getRole(req, res, decodedObjectName, defaultRole) {
 
   /**
    * if decodedObjectName provided in configurations
    * and role is attached to request[decodedObjectName]
    * Return role
    */
-  if (options.decodedObjectName &&
-    req[options.decodedObjectName] &&
-    req[options.decodedObjectName].role) {
-    return req[options.decodedObjectName].role;
+  if (decodedObjectName && req[decodedObjectName] && req[decodedObjectName].role) {
+    return req[decodedObjectName].role;
   }
 
   /**
@@ -84,7 +79,7 @@ function getRole(req, res, options) {
    * Return role
    */
 
-  return utils.deny(res, 404, 'REQUIRED: Role not found');
+  return defaultRole;
 }
 
 
@@ -101,10 +96,8 @@ function resource(next, url, baseUrl) {
   let lengthOfTheBaseUrl = (base) ? base.length : 0;
   let arr = url.match(/([A-Z])\w+/gi);
 
-  if (arr) {
-    arr = arr.splice(lengthOfTheBaseUrl);
-    return arr[0];
-  }
+  if (arr) return arr.splice(lengthOfTheBaseUrl)[0];
+
   return next();
 }
 

--- a/lib/nacl.js
+++ b/lib/nacl.js
@@ -23,6 +23,7 @@ function config(config, response) {
   opt.response = response;
   opt.baseUrl = options.baseUrl;
   opt.decodedObjectName = options.decodedObjectName;
+  opt.defautRole = options.defautRole || 'guest';
 
   if (options.rules) {
     opt.rules = utils.validate(options.rules);
@@ -40,9 +41,7 @@ function config(config, response) {
    * Merge filename and path
    */
 
-  let path = filename && options.path ?
-    (`${options.path}/${filename}`) : filename;
-
+  let path = filename && options.path ? (`${options.path}/${filename}`) : filename;
 
   opt.rules = helper.getRules(path, options.encoding, yml);
 
@@ -64,20 +63,16 @@ function authorize(req, res, next) {
    * if not resource terminate script
    */
 
-  if (!resource || !_.isString(resource)) {
-    return;
-  }
+  if (!resource || !_.isString(resource)) return;
 
   /**
    * [group description]
    * @type {[type]}
    */
 
-  let role = helper.getRole(req, res, opt);
+  let role = helper.getRole(req, res, opt.decodedObjectName, opt.defautRole);
 
-  if (!_.isString(role) || !role) {
-    return;
-  }
+  if (!_.isString(role) || !role) return;
 
   /**
    * get resource from the url

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -14,8 +14,7 @@ function deny(res, status, customMessage, response) {
   let message = customMessage ? customMessage : 'Unauthorized access';
 
   if (response && typeof response === 'object') {
-    return res.status(status)
-      .send(response);
+    return res.status(status).send(response);
   }
 
   return res.status(status)
@@ -38,9 +37,7 @@ function deny(res, status, customMessage, response) {
  */
 
 function whenGlobAndActionAllow(res, next, method, methods, response) {
-  if (_.isString(methods)) {
-    return next();
-  }
+  if (_.isString(methods)) return next();
 
   /**
    * [if Its an array of  methods]

--- a/tests/behavior/nacl.authorize.spec.js
+++ b/tests/behavior/nacl.authorize.spec.js
@@ -3,7 +3,7 @@ const assert = require('assert');
 const acl = require('../../');
 const httpMocks = require('node-mocks-http');
 
-describe('Authorize middleware', function() {
+describe('Authorize middleware', function () {
   let req, res, data, next;
   let response = {
     success: {
@@ -18,9 +18,9 @@ describe('Authorize middleware', function() {
     }
   };
 
-  beforeEach(function(done) {
+  beforeEach(function (done) {
     res = httpMocks.createResponse();
-    next = function() {
+    next = function () {
       res.send({
         status: 200,
         success: true,
@@ -30,8 +30,8 @@ describe('Authorize middleware', function() {
     done();
   });
 
-  context('When request comes from home route', function() {
-    beforeEach(function(done) {
+  context('When request comes from home route', function () {
+    beforeEach(function (done) {
       acl.config();
       req = httpMocks.createRequest({
         method: 'GET',
@@ -42,7 +42,7 @@ describe('Authorize middleware', function() {
       done();
     });
 
-    it('should allow traffic for the home route', function(done) {
+    it('should allow traffic for the home route', function (done) {
       acl.authorize(req, res, next);
       data = res._getData();
       assert(data, true);
@@ -52,9 +52,9 @@ describe('Authorize middleware', function() {
 
   });
 
-  context('When role is defined in the user object', function() {
+  context('When role is defined in the user object', function () {
 
-    beforeEach(function(done) {
+    beforeEach(function (done) {
       acl.config({ baseUrl: 'api' });
       req = httpMocks.createRequest({
         method: 'GET',
@@ -67,7 +67,7 @@ describe('Authorize middleware', function() {
     });
 
 
-    it('should allow when role is defined on /api/user/42', function(done) {
+    it('should allow when role is defined on /api/user/42', function (done) {
       req.decoded.role = 'user';
       acl.authorize(req, res, next);
       data = res._getData();
@@ -77,16 +77,16 @@ describe('Authorize middleware', function() {
     });
   });
 
-  describe('Testing Access With roles', function() {
+  describe('Testing Access With roles', function () {
 
-    context('When role is not defined in the user object', function() {
-      it('should block traffic if no role is defined', function(done) {
+    context('When role is not defined in the user object', function () {
+      it('should block traffic if no role is defined', function (done) {
         req.decoded = {};
         acl.authorize(req, res, next);
         let expectedResponse = {
           status: 'Access denied',
           success: false,
-          message: 'REQUIRED: Role not found'
+          message: 'REQUIRED: Group not found'
         };
 
         data = res._getData();
@@ -97,8 +97,8 @@ describe('Authorize middleware', function() {
       });
     });
 
-    context('When no policy is defined for such role', function() {
-      it('should deny access if no policy for such role', function(done) {
+    context('When no policy is defined for such role', function () {
+      it('should deny access if no policy for such role', function (done) {
         req.decoded.role = 'guest';
         acl.authorize(req, res, next);
         let expectedResponse = {
@@ -114,13 +114,13 @@ describe('Authorize middleware', function() {
       });
     });
 
-    context('When action is allow ', function() {
-      beforeEach(function(done) {
+    context('When action is allow ', function () {
+      beforeEach(function (done) {
         acl.config({ baseUrl: 'api' });
         done();
       });
 
-      it('Should allow access to /api/user/42', function(done) {
+      it('Should allow access to /api/user/42', function (done) {
         req = httpMocks.createRequest({
           method: 'POST',
           url: '/api/users/42'
@@ -136,7 +136,7 @@ describe('Authorize middleware', function() {
         done();
       });
 
-      it('Should allow access to resource  /api/user/42', function(done) {
+      it('Should allow access to resource  /api/user/42', function (done) {
         req = httpMocks.createRequest({
           method: 'PUT',
           url: '/api/users/42'
@@ -152,7 +152,7 @@ describe('Authorize middleware', function() {
         done();
       });
 
-      it('Should deny access to resource /api/user/42', function(done) {
+      it('Should deny access to resource /api/user/42', function (done) {
         req = httpMocks.createRequest({
           method: 'DElETE',
           url: '/api/users/42'
@@ -172,8 +172,8 @@ describe('Authorize middleware', function() {
     });
 
 
-    context('When action deny', function() {
-      beforeEach(function(done) {
+    context('When action deny', function () {
+      beforeEach(function (done) {
         acl.config({
           baseUrl: 'api',
           filename: 'deny-user-config.json',
@@ -182,7 +182,7 @@ describe('Authorize middleware', function() {
         done();
       });
 
-      it('Should deny access to resource /api/user/42', function(done) {
+      it('Should deny access to resource /api/user/42', function (done) {
         req = httpMocks.createRequest({
           method: 'POST',
           url: '/api/users/42'
@@ -201,7 +201,7 @@ describe('Authorize middleware', function() {
       });
 
 
-      it('Should deny access to resource /api/user/42', function(done) {
+      it('Should deny access to resource /api/user/42', function (done) {
         req = httpMocks.createRequest({
           method: 'PUT',
           url: '/api/users/42'
@@ -220,7 +220,7 @@ describe('Authorize middleware', function() {
         done();
       });
 
-      it('Should allow access to resource /api/user/42', function(done) {
+      it('Should allow access to resource /api/user/42', function (done) {
         req = httpMocks.createRequest({
           method: 'DElETE',
           url: '/api/users/42'
@@ -239,16 +239,16 @@ describe('Authorize middleware', function() {
 
     });
 
-    context('When not policy is defined', function() {
+    context('When not policy is defined', function () {
 
-      beforeEach(function(done) {
+      beforeEach(function (done) {
         acl.config({
           baseUrl: 'api'
         });
         done();
       });
 
-      it('should deny if not policy match resource', function(done) {
+      it('should deny if not policy match resource', function (done) {
         req = httpMocks.createRequest({
           method: 'POST',
           url: '/api/cargo/42'

--- a/tests/unit/helpers.spec.js
+++ b/tests/unit/helpers.spec.js
@@ -5,16 +5,16 @@ const httpMocks = require('node-mocks-http');
 const spies = require('chai-spies');
 const expect = chai.expect;
 
-describe('Helpers test', function() {
+describe('Helpers test', function () {
 
-  context('getRules', function() {
+  context('getRules', function () {
     let path, rules;
 
-    beforeEach(function() {
+    beforeEach(function () {
       path = './tests/config/config.json';
     });
 
-    it('Should return an array containing the rules', function() {
+    it('Should return an array containing the rules', function () {
       rules = helper.getRules(path, null, false);
       let permissions = rules.get('user');
       expect(rules.has('user')).to.equal(true);
@@ -23,7 +23,7 @@ describe('Helpers test', function() {
       expect(permissions[0]).to.have.property('action');
     });
 
-    it('Should throw an error', function() {
+    it('Should throw an error', function () {
       try {
         rules = helper.getRules(path, 1, true);
       } catch (err) {
@@ -33,8 +33,8 @@ describe('Helpers test', function() {
   });
 
 
-  context('getPolicy', function() {
-    it('Should return the permissions specified', function() {
+  context('getPolicy', function () {
+    it('Should return the permissions specified', function () {
       let mockResource = 'users';
       let mockGroup = [{
         resource: 'users',
@@ -65,7 +65,6 @@ describe('Helpers test', function() {
         role: 'user'
       };
       let role = helper.getRole(req, res);
-
       expect(role).to.not.be.empty;
       expect(role).to.equal(req.decoded.role);
     });
@@ -75,7 +74,6 @@ describe('Helpers test', function() {
         role: 'admin'
       };
       let role = helper.getRole(req, res);
-
       expect(role).to.not.be.empty;
       expect(role).to.equal(req.session.role);
     });
@@ -89,35 +87,30 @@ describe('Helpers test', function() {
       req[opt.decodedObjectName] = {
         role: 'admin'
       };
-      let role = helper.getRole(req, res, opt);
+      let role = helper.getRole(req, res, opt.decodedObjectName);
 
       expect(role).to.not.be.empty;
       expect(role).to.equal(req[opt.decodedObjectName].role);
     });
 
-    it('Should respond with 404', function() {
-      let error = {
-        message: 'REQUIRED: Role not found'
-      };
-      let role = helper.getRole(req, res);
-      let data = res._getData();
-
-      expect(role).to.be.empty;
-      expect(res.statusCode).to.equal(404);
-      expect(data.message).to.equal(error.message);
+    it('Should return default role if user has no role defined', function () {
+      let defaultRole = 'guest'
+      let role = helper.getRole(req, res, undefined, defaultRole);
+      expect(role).not.to.be.empty;
+      expect(role).to.eq(defaultRole);
     });
   });
 
-  context('resource', function() {
+  context('resource', function () {
     let next;
 
-    beforeEach(function() {
-      next = function() {
+    beforeEach(function () {
+      next = function () {
         return;
       };
     });
 
-    it('Should return the resource for a given url', function() {
+    it('Should return the resource for a given url', function () {
       let url = '/api/user/4';
       let baseUrl = 'api';
       let resource = helper.resource(next, url, baseUrl);
@@ -126,7 +119,7 @@ describe('Helpers test', function() {
       expect(resource).to.equal('user');
     });
 
-    it('Should call next', function() {
+    it('Should call next', function () {
       chai.use(spies);
       let url = '';
       let baseUrl = 'api';


### PR DESCRIPTION
### What does this PR do?

This PR is meant to address issue #70. It introduces way of  assigning users default role they can assume instead of returning a 404 error. This makes the module more dynamic and configurable.
