### PR TITLE
Fix: Issue#79: called the utils.deny function when the validation whe…

### DIFF
--- a/lib/nacl.js
+++ b/lib/nacl.js
@@ -72,7 +72,17 @@ function authorize(req, res, next) {
 
   let role = helper.getRole(req, res, opt.decodedObjectName, opt.defaultRole);
 
-  if (!_.isString(role) || !role) return;
+  /**
+   * if no role or role not provided as string
+   */
+  if (!_.isString(role) || !role) {
+    return utils.deny(
+      res,
+      404,
+      'REQUIRED: Role should be provided as a string',
+      null
+    );
+  }
 
   /**
    * get resource from the url


### PR DESCRIPTION
Fix: Issue#79: called the utils.deny function when the validation whether the provided role is a string or not fails.

#### What does this PR do?
This PR calls fixes the bug in authorize function in which if the provided role is not a string, the function fails to call the deny function which sends a proper response. Instead, this simply returns which hangs the application.

#### Description of Task to be completed?
The task is to call the deny function if the role string validation fails.

#### How should this be manually tested?
This can be manually tested by provided an integer role to the acl.authorize middleware.

#### Any background context you want to provide?
The details for this issue are at: https://github.com/nyambati/express-acl/issues/79

#### What are the relevant pivotal tracker stories?

#### Screenshots (if appropriate)

### Questions: