### PR TITLE
added option to find role in a deep path

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@ This methods loads the configuration json file. When this method it looks for `n
 - **rules**: Allows you to set rules directly withour using config file.
 - **defaultRole** : The default role to be assigned to users if they have no role defined.
 - **decodedObjectName**: The name of the object in the request where the role resides.
+- **searchPath**: The path in which to look for the role within the req object
 
 ```js
   const acl = require('express-acl');
@@ -212,6 +213,13 @@ This methods loads the configuration json file. When this method it looks for `n
   acl.config({
     decodedObjectName:'user'
   })
+
+// You can also specify a deep path in which to look for the role, in case it's not inside the usual locations
+
+  acl.config({
+    searchPath: 'user.Role.name' //will search for role in req.user.Role.name
+  })
+
 
 ```
 ## Response

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -1,9 +1,10 @@
 'use strict';
-const fs = require('fs');
-const utils = require('./utils');
-const yaml = require('js-yaml');
-const _ = require('lodash');
 
+const fs          = require('fs');
+const utils       = require('./utils');
+const yaml        = require('js-yaml');
+const _           = require('lodash');
+const objectPath  = require("object-path");
 /**
  * Get the rules from the specified file path
  * @param {[String]} path
@@ -47,7 +48,15 @@ function getPolicy(permissions, resource) {
 }
 
 
-function getRole(req, res, decodedObjectName, defaultRole) {
+function getRole(req, res, decodedObjectName, defaultRole, searchPath) {
+
+  /**
+   * Checking for path first, because if it's defined
+   * it surely is so because that's where the role is
+   */
+  if(searchPath) {
+    return objectPath.get(req, searchPath);
+  }
 
   /**
    * if decodedObjectName provided in configurations

--- a/lib/nacl.js
+++ b/lib/nacl.js
@@ -24,6 +24,7 @@ function config(config, response) {
   opt.baseUrl = options.baseUrl;
   opt.decodedObjectName = options.decodedObjectName;
   opt.defaultRole = options.defaultRole || 'guest';
+  opt.searchPath = options.searchPath || undefined;
 
   if (options.rules) {
     opt.rules = utils.validate(options.rules);
@@ -70,7 +71,7 @@ function authorize(req, res, next) {
    * @type {[type]}
    */
 
-  let role = helper.getRole(req, res, opt.decodedObjectName, opt.defaultRole);
+  let role = helper.getRole(req, res, opt.decodedObjectName, opt.defaultRole, opt.searchPath);
 
   /**
    * if no role or role not provided as string

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
   "dependencies": {
     "express-unless": "^0.3.0",
     "js-yaml": "^3.6.0",
-    "lodash": "^4.11.2"
+    "lodash": "^4.11.2",
+    "object-path": "^0.11.4"
   },
   "devDependencies": {
     "chai-spies": "^0.7.1",

--- a/tests/unit/helpers.spec.js
+++ b/tests/unit/helpers.spec.js
@@ -99,6 +99,18 @@ describe('Helpers test', function () {
       expect(role).not.to.be.empty;
       expect(role).to.eq(defaultRole);
     });
+
+    it('Should return role from a deep path', function () {
+      let path = 'guest';
+      req.user = {
+        Role: {
+          name: 'admin'
+        }
+      }
+      let role = helper.getRole(req, res, undefined, undefined, 'user.Role.name');
+      expect(role).not.to.be.empty;
+      expect(role).to.eq(req.user.Role.name);
+    });
   });
 
   context('resource', function () {


### PR DESCRIPTION
My role name resides deep inside the req object. None of the supported options were good for me to find my role. So, I added the hability to specify a deep path and have the module search for the role there.

Added the proper test in `helpers.spec.js`