### PR TITLE
Allow searchPath & defaultRole, resolve issue #78

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -54,7 +54,7 @@ function getRole(req, res, decodedObjectName, defaultRole, searchPath) {
    * Checking for path first, because if it's defined
    * it surely is so because that's where the role is
    */
-  if(searchPath) {
+  if(searchPath && objectPath.get(req, searchPath)) {
     return objectPath.get(req, searchPath);
   }
 
@@ -105,7 +105,9 @@ function resource(next, url, baseUrl) {
   let lengthOfTheBaseUrl = (base) ? base.length : 0;
   let arr = url.match(/([A-Z])\w+/gi);
 
-  if (arr) return arr.splice(lengthOfTheBaseUrl)[0];
+  if (arr) {
+    return arr.splice(lengthOfTheBaseUrl).join('/');
+  };
 
   return next();
 }


### PR DESCRIPTION

#### What does this PR do?
Allows the use of both searchPath & defaultRole so "guest" users have access to authentication methods. Also allows routes "/api/some/long/route" vs. a signal resource.

#### Description of Task to be completed?
None

#### How should this be manually tested?
Add a route "/api/any/route" to the resource in the rules.

#### Any background context you want to provide?
We have a lot of "/api/very/long/routes"

#### What are the relevant pivotal tracker stories?
#78

#### Screenshots (if appropriate)

### Questions: