### PR TITLE
resolved argument mismatch on whenResourceAndMethodGlob function call

### DIFF
--- a/lib/nacl.js
+++ b/lib/nacl.js
@@ -167,7 +167,6 @@ function authorize(req, res, next) {
         res,
         next,
         policy.action,
-        methods,
         opt.response
       );
     }


### PR DESCRIPTION
function was called with incorrect arguments. removed unnecessary
`methods` argument, which was preventing custom responses from sending
for the resource specified and method glob case.