### PR TITLE
Fix typo in all documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,9 +92,9 @@ First step is to create a file called `nacl.json` and place this in the root fol
   "group": "admin",
   "permissions": [{
     "resource": "*",
-    "methods": "*"
-  }],
-  "action": "allow"
+    "methods": "*",
+    "action": "allow"
+  }]
   }, {
   "group": "user",
   "permissions": [{
@@ -199,13 +199,13 @@ This methods loads the configuration json file. When this method it looks for `n
   });
 
   // When you use rules api, nacl will **not** to find the json/yaml file, so you can save your acl-rules with any Database;
-  
+
 // The default role alllows you to specify which role users will assumne if they are not assigned any
   acl.config({
     defaultRole: 'anonymous'
   });
 
-  
+
 // By default this module will look for role in decoded object, if you would like to change the name of the object, you can specify this with decodedObjectName property.
 
 // As per the example below, this module will look for req.user.role as compared to default req.decoded.role.

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ Property | Type | Description
   **action** | `string` | This property tell express-acl what action to perform on the permission given. Using the above example, the user policy specifies a deny action, meaning all traffic on route `/api/users` for methods `GET, PUT, POST` are denied, but the rest allowed. And for the admin, all traffic for all resource is allowed.
 
 ## How to define effective ACL rules
-ACLs define the way requests will be handled by express acl, therefore its important to ensure that they are well designed to maximise efficiency. For more details follow this [link](https://github.com/andela-thomas/express-acl/wiki/How-to-write-effective-ACL-rules)
+ACLs define the way requests will be handled by express acl, therefore its important to ensure that they are well designed to maximize efficiency. For more details follow this [link](https://github.com/andela-thomas/express-acl/wiki/How-to-write-effective-ACL-rules)
 
 ## Authentication
 express-acl depends on the role of each authenticated user to pick the corresponding ACL policy for each defined user groups. Therefore, You should always place the acl middleware after the authenticate middleware. Example using jsonwebtoken middleware
@@ -162,7 +162,7 @@ This methods loads the configuration json file. When this method it looks for `n
 - **path**: Location of the ACL rule file
 - **yml**: when set to true means use yaml parser else JSON parser
 - **baseUrl**: The base url of your API e.g /developer/v1
-- **rules**: Allows you to set rules directly withour using config file.
+- **rules**: Allows you to set rules directly without using config file.
 - **defaultRole** : The default role to be assigned to users if they have no role defined.
 - **decodedObjectName**: The name of the object in the request where the role resides.
 - **searchPath**: The path in which to look for the role within the req object
@@ -200,7 +200,7 @@ This methods loads the configuration json file. When this method it looks for `n
 
   // When you use rules api, nacl will **not** to find the json/yaml file, so you can save your acl-rules with any Database;
 
-// The default role alllows you to specify which role users will assumne if they are not assigned any
+// The default role allows you to specify which role users will assume if they are not assigned any
   acl.config({
     defaultRole: 'anonymous'
   });
@@ -251,7 +251,7 @@ app.get(acl.authorize);
 
 ```
 ## unless[type:function, params: function or object]
-By default any route that has no defined policy against it is blocked, this means you cannot access this route untill you specify a policy. This method enables you to exclude unprotected routes. This method uses express-unless package to achive this functionality. For more details on its usage follow this link [express-unless](https://github.com/jfromaniello/express-unless/blob/master/README.md)
+By default any route that has no defined policy against it is blocked, this means you cannot access this route until you specify a policy. This method enables you to exclude unprotected routes. This method uses express-unless package to achieve this functionality. For more details on its usage follow this link [express-unless](https://github.com/jfromaniello/express-unless/blob/master/README.md)
 
 ```js
 //assuming we want to hide /auth/google from express acl
@@ -260,7 +260,7 @@ app.use(acl.authorize.unless({path:['/auth/google']}));
 
 ```
 
-Anytime that this route is visited, unless method will exlude it from being passed though our middleware.
+Anytime that this route is visited, unless method will exclude it from being passed though our middleware.
 
 **N/B** You don't have to install `express-unless` it has already been included into the project.
 

--- a/docs/documentation/configuration.md
+++ b/docs/documentation/configuration.md
@@ -1,6 +1,6 @@
 # Overview
 
-This are the options that are passed to the config method. This options determin how the rules will be loaded and how resource matching should start from.
+This are the options that are passed to the config method. This options determine how the rules will be loaded and how resource matching should start from.
 
 The config method takes in an object with possible five parameters, They include
 
@@ -84,7 +84,7 @@ This is the encoding type `fs` module uses to read nacl file. For more informati
 
 The base URL represent the prefix of your API. This can either be `api`,`v1`,`/developer/v1` etc. This is important because express-acl will use this url to map the location of the resources. Take an example of the following url `/api/users`.
 
-In this URL our resource is users,and the base URL being `api`. If we donot specify the base URL express will treat `api` as our resource instead of `users`.
+In this URL our resource is users, and the base URL being `api`. If we do not specify the base URL express will treat `api` as our resource instead of `users`.
 
 ```js
 
@@ -147,7 +147,7 @@ acl.config({
 
 ## Search Path And Decoded Object Name
 
-This two properties enable you to customize how and where your user role will be located in the request object. By default this module looks for `req.decoded.role`, However this might be the case with everyone. if your decoed object uses different format you can specify using the above properties.
+This two properties enable you to customize how and where your user role will be located in the request object. By default this module looks for `req.decoded.role`, However this might be the case with everyone. if your decoded object uses different format you can specify using the above properties.
 
 !!! note
     Both of these properties are use to locate the role in your request object, therefore  they cannot be used together.

--- a/docs/documentation/getting-started.md
+++ b/docs/documentation/getting-started.md
@@ -27,7 +27,7 @@ For more details check the [configuration options](/documentation/configuration)
 
 ## Adding Rules
 
-The config method loads the rules for the local file. By default this module will look for `nacl.json` file in the root folder of your project. This can be overidden by adding more options to the config method as we have added yml which will look for `nacl.yml` file instead.
+The config method loads the rules for the local file. By default this module will look for `nacl.json` file in the root folder of your project. This can be overridden by adding more options to the config method as we have added yml which will look for `nacl.yml` file instead.
 
 ```yaml
 
@@ -41,13 +41,13 @@ The config method loads the rules for the local file. By default this module wil
       action: allow
 ```
 
-This file instructs this module on how to manage access to your resources. The contets of this file will be covered in details in the [Acl rules](/documentation/acl-rules) section
+This file instructs this module on how to manage access to your resources. The contents of this file will be covered in details in the [Acl rules](/documentation/acl-rules) section
 
 ## Authentication
 
 Express Acl depends on the `role` of each authenticated user to pick the corresponding ACL policy for each defined user groups. Therefore, You should always place the acl middleware after the authenticate middleware.
 
-Below is an example of an Authenticatio middleware implementation using jsonwebtokens.
+Below is an example of an Authentication middleware implementation using jsonwebtokens.
 
 ```js
 
@@ -77,4 +77,4 @@ ROUTER.use(acl.authorize);
 
 ```
 
-Once this middware is called, express-acl will pick the role from the authenticated user,and apply corresponding polices dependng on he role and resource sbeing requested for.
+Once this middleware is called, express-acl will pick the role from the authenticated user, and apply corresponding polices depending on he role and resource accessing requested for.

--- a/docs/documentation/methods.md
+++ b/docs/documentation/methods.md
@@ -13,8 +13,8 @@ app.get(acl.authorize);
 ## unless
     [type:function, params: function or object]
 
-By default any route that has no defined policy against it is blocked, this means you cannot access this route untill you specify a policy.
-This method enables you to exclude unprotected routes. This method uses express-unless package to achive this functionality.
+By default any route that has no defined policy against it is blocked, this means you cannot access this route until you specify a policy.
+This method enables you to exclude unprotected routes. This method uses express-unless package to achieve this functionality.
 For more details on its usage follow this link [express-unless](https://github.com/jfromaniello/express-unless/blob/master/README.md)
 
 ```js
@@ -24,7 +24,7 @@ app.use(acl.authorize.unless({path:['/auth/google']}));
 
 ```
 
-Anytime that this route is visited, unless method will exlude it from being passed though our middleware.
+Anytime that this route is visited, unless method will exclude it from being passed though our middleware.
 
 !!! note
     You don't have to install express-unless it has already been included into the project.

--- a/docs/documentation/rules.md
+++ b/docs/documentation/rules.md
@@ -51,7 +51,7 @@ YAML syntax
 
 ## Understanding ACL rules
 
-Its important to Understand each property that consitute an acl. Below is a table that has a Description of each property.
+Its important to Understand each property that constitute an acl. Below is a table that has a Description of each property.
 
 Property | Type | Description
     --- | --- | ---
@@ -97,7 +97,7 @@ You may ask, why did we apply deny action on DELETE method instead of allowing o
 
 Thus denying one method is faster than allowing three or four methods. When it comes to blogs we only need them to read therefore we allow GET methods which means the other methods are denied.
 
-For you to formulate good ACL rules, you need to understand the princple of negation. To allow is to deny and to deny is to allow, confusing right? how can you deny and allow at the same time?. Lets look at this example, if I have 4 methods POST, GET, PUT, DELETE and I deny POST. This is same as saying allow GET,PUT,DELETE and if I allow POST is same as saying deny GET,PUT,DELETE.
+For you to formulate good ACL rules, you need to understand the principle of negation. To allow is to deny and to deny is to allow, confusing right? how can you deny and allow at the same time?. Lets look at this example, if I have 4 methods POST, GET, PUT, DELETE and I deny POST. This is same as saying allow GET,PUT,DELETE and if I allow POST is same as saying deny GET,PUT,DELETE.
 
 Now that we have established that lets write our config file. Our nacl.json will look like this.
 

--- a/docs/documentation/status-and-responses.md
+++ b/docs/documentation/status-and-responses.md
@@ -2,7 +2,7 @@
 
 Express acl return  status codes and responses when authorization fails. In this section We will look into these codes and scenarios that might trigger such responses.
 
-When Authorization fails,this module returns a json response with the following properties.
+When Authorization fails, this module returns a json response with the following properties.
 
 - status
 - success
@@ -10,7 +10,7 @@ When Authorization fails,this module returns a json response with the following 
 
 ## Missing role
 
-Express acl uses user's role to match the approriate policy to use. Therefore it is required that each use object to have a role defined. However if the user role is not defined, Express acl will deny that user access to the system.
+Express acl uses user's role to match the appropriate policy to use. Therefore it is required that each use object to have a role defined. However if the user role is not defined, Express acl will deny that user access to the system.
 
 ```json
 {
@@ -23,7 +23,7 @@ Express acl uses user's role to match the approriate policy to use. Therefore it
 This error will also return a status of `404`
 
 ## Missing Group
-Policies are defined under user groups. This enables us to group users using roles and define policies through groups insted of doing it per user. If a user group is not defined this means that users of that role will not be gived access to the system. Therefore if you have a role associated to users, ensure that such role has been defined in your rules configurations.
+Policies are defined under user groups. This enables us to group users using roles and define policies through groups insted of doing it per user. If a user group is not defined this means that users of that role will not be given access to the system. Therefore if you have a role associated to users, ensure that such role has been defined in your rules configurations.
 
 ```json
 {
@@ -46,4 +46,3 @@ When a user is trying to access a resource that they are not allowed access to, 
   "message":"Unauthorized access"
 }
 ```
-

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,7 +2,7 @@
 
 # Express Acl
 
-This is NodeJs runtime module that Implements ACL for expressJS Application. Its is designed to provide configuration approach to ACL implemantation as saving you the nightmare of writing countless middlewares. It suppports JSON and YAML as the configuration syntax.
+This is NodeJs runtime module that Implements ACL for expressJS Application. Its is designed to provide configuration approach to ACL implementation as saving you the nightmare of writing countless middlewares. It supports JSON and YAML as the configuration syntax.
 
 [Installation](/documentation/getting-started/#installation)
 


### PR DESCRIPTION
#### What does this PR do?
This PR fix the typo in README file configuration example JSON and fix all docs typo.
#### Description of Task to be completed?
Fix typo in all documentation
#### How should this be manually tested?
This typo can be tested by manually through use of the provided example in **Configuration** section.
and others docs typo
#### Any background context you want to provide?
None
#### What are the relevant pivotal tracker stories?
None
#### Screenshots (if appropriate)
None
### Questions: