### PR TITLE
Strip Query string from route before being passed to findPermissionForRoute function

### DIFF
--- a/lib/common.js
+++ b/lib/common.js
@@ -17,6 +17,8 @@ const urlToArray = url => {
   return url.replace(/^\/+|\/+$/gm, '').split('/');
 };
 
+const stripQueryStrings = url => url.split(/[?#]/)[0];
+
 /**
  * deny method is used to buid the deny response Object
  *
@@ -163,6 +165,9 @@ const matchUrlToResource = (route, resource) => {
 const getPrefix = resource => resource.slice(0, resource.length - 2);
 
 const findPermissionForRoute = (route, method, prefix = '', policy) => {
+  // Strip query strings from route
+  route = stripQueryStrings(route);
+
   for (let permission of policy) {
     let resource = permission.resource;
     // check if route prefix has been specified

--- a/tests/behavior/nacl.subroutes.spec.js
+++ b/tests/behavior/nacl.subroutes.spec.js
@@ -43,6 +43,7 @@ describe('Test Sub Routes configurration', () => {
 
       done();
     });
+
     it('Should allow traffic for api/users/public', done => {
       const req = http.createRequest({
         method: 'GET',
@@ -52,6 +53,19 @@ describe('Test Sub Routes configurration', () => {
       req.decoded = {
         role: 'user'
       };
+
+      const data = acl.authorize(req, res, next);
+      assert.deepEqual(data, next());
+      done();
+    });
+
+    it('Should allow traffic for api/users/public when query string is added', done => {
+      const req = http.createRequest({
+        method: 'GET',
+        url: '/api/users/public?string=true'
+      });
+
+      req.decoded = { role: 'user' };
 
       const data = acl.authorize(req, res, next);
       assert.deepEqual(data, next());


### PR DESCRIPTION
#### What does this PR do?
This PR is mean to fix issue #98. When the route is passed with the query parameters, `findPermissionForRoute` is unable to match any permissions. With the current changes the query strings are striped before being passed to `findPermissionForRoute` function.

Finished Issue #98 