### PR TITLE
fix a bug that sometimes resulted in startsWith is not a function error

### DIFF
--- a/lib/common.js
+++ b/lib/common.js
@@ -136,14 +136,18 @@ const matchUrlToResource = (route, resource) => {
   const routeArray = urlToArray(route);
   const resourceArray = urlToArray(resource);
 
-  for (let key in routeArray) {
-    if (key >= resourceArray.length) return false;
+  let found = null;
 
-    if (resourceArray[key] === '*') return true;
+  routeArray.forEach((route, i) => {
+    if (found !== null) return;
+    if (i >= resourceArray.length) found = false;
 
-    if (!routeArray[key].match(createRegexFromResource(resourceArray[key])))
-      return false;
-  }
+    if (resourceArray[i] === '*') found = true;
+
+    if (!route.match(createRegexFromResource(resourceArray[i]))) found = false;
+  });
+
+  if (found !== null) return found;
 
   if (resourceArray.length > routeArray.length) {
     return resourceArray[routeArray.length] == '*';


### PR DESCRIPTION
#### What does this PR do?

It fixes a bug. The for loop would sometimes get beyond the limit and call the startsWith function on a function and not a string. It is now fixed.

#### Description of Task to be completed?

#### How should this be manually tested?

#### Any background context you want to provide?

#### What are the relevant pivotal tracker stories?

#### Screenshots (if appropriate)

### Questions: