### PR TITLE
Fixes the logic of findPermissionForRoute function.

### DIFF
--- a/lib/common.js
+++ b/lib/common.js
@@ -182,10 +182,8 @@ const findPermissionForRoute = (route, method, prefix = '', policy) => {
     }
 
     if (matchUrlToResource(route, resource)) {
-		if (isAllowed(method, permission)) {
       return permission;
     }
-  }
   }
 };
 


### PR DESCRIPTION
#### What does this PR do?
Fixes the logic of **findPermissionForRoute** function.
Properly check for subRoutes permission.
Fixes #125 
#### Any background context you want to provide?
`findPermissionForRoute` should only do what it is called, which is finding the correct permission rule for the route.
It should not interfere with the access decision.

`isAllowed` is called and evaluated in `checkIfHasAccess` which is correct. evaluating it again in `findPermissionForRoute` is wrong.

Now you can do things like the following:
This is simple, it works
```js
{
  group: "admin",
  permissions: [
    {
      resource: "*",
      methods: "*",
      action: "allow"
    }
  ]
}
```
However, you couldn't do complicated rules like this:
```js
{
group: "moderator",
{
  group: "editor",
  permissions: [
    {
      resource: "reports/*",
      methods: "*",
      action: "deny"
    },
    {
      resource: "settings/*",
      methods: "*",
      action: "allow",
      subRoutes: [
        {
          resource: "admin/*",
          methods: "*",
          action: "deny"
        }
      ]
    },
    {
      resource: "*",
      methods: "*",
      action: "allow"
    }
  ]
}
```
Now you can allow a root route, and deny part of it (subroutes). **Before it allowed all even denied subroutes**

And you can set your deny rules on top, then at bottom set less restrictive rules, which also didn't work before.

It is very simple fix, just removal of a line in the wrong place, that probably ended up there by mistake.